### PR TITLE
using node16

### DIFF
--- a/tasks/operation/Dockerfile
+++ b/tasks/operation/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.10
+FROM node:16-alpine3.14
 
 USER root
 WORKDIR /root/cdkbot
 
-RUN apk add --no-cache nodejs npm make gcc libc-dev git docker && \
+RUN apk add --no-cache make gcc libc-dev git docker && \
     git config --global user.name cdkbot && \
     git config --global user.email operation@cdkbot.localhost
 


### PR DESCRIPTION
The Node.js version in alpine 3.10 is 10.x, but latest aws-cdk does not support that version.

So using node image instead of plain alpine image and lock version to 16(current LTS).